### PR TITLE
radar_sync review

### DIFF
--- a/tools/radar_sync.py
+++ b/tools/radar_sync.py
@@ -41,6 +41,9 @@ import paramiko
 from pydoop import hdfs
 
 
+DEFAULT_SSH_PORT = 22
+
+
 class SSHClient():
     """
     Class that handles ssh/sftp remote connections and operations.
@@ -48,7 +51,7 @@ class SSHClient():
     def __init__(self,
                  username,
                  hostname,
-                 port=22,
+                 port=DEFAULT_SSH_PORT,
                  key_file=None,
                  root_dir='/'):
         self._hostname = hostname
@@ -200,7 +203,8 @@ def check_ssh_url(ssh_url):
             return (None, None, None, None)
 
         return (_match.group('user'), _match.group('host'),
-                int(_match.group('port')), _match.group('path'))
+                int(_match.group('port') or DEFAULT_SSH_PORT),
+                _match.group('path'))
 
     return (None, None, None, None)
 

--- a/tools/radar_sync.py
+++ b/tools/radar_sync.py
@@ -1,29 +1,27 @@
-#!/usr/bin/env python3
-"""Radar Sync
+# Copyright 2018-2019 CRS4
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-This script performs a copy of meteorological images from an SFTP folder
+"""\
+Performs a copy of meteorological images from an SFTP folder
 to an HDFS one. The path for both the source and destination folders are
-compliant to the TDM folder convention for meteorological images:
+compliant with the TDM folder convention for meteorological images:
 
     <ROOT_DIR>/YYYY/MM/DD/
 
 Files are copied to HDFS only if the destination folder does not exist or the
-count of files contained differs from the one of the source folder. No hash or
-size check is performed.
-
-Copyright 2019 CRS4
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+file count differs from that of the source folder. No hash or size check is
+performed.
 """
 
 # pylint: disable=import-error, broad-except


### PR DESCRIPTION
This PR is part of a review for tdm-project#43

1. Move copyright section out of the docstring (rings the copyright notice in line with the other modules)
2. Fix unhandled `TypeError` when user does not explicitly provide an SSH port